### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/includes.js
+++ b/assets/js/includes.js
@@ -4,6 +4,20 @@
 // This enables modularitys to the site by allowing HTML snippets to be reused across multiple pages
 let sidebarLoaded = false;
 let arrowsLoaded = false;
+// Escapes HTML metacharacters in a string
+function escapeHTML(str) {
+  return str.replace(/[&<>"']/g, function(m) {
+    switch (m) {
+      case "&": return "&amp;";
+      case "<": return "&lt;";
+      case ">": return "&gt;";
+      case '"': return "&quot;";
+      case "'": return "&#39;";
+      default: return m;
+    }
+  });
+}
+
 document.querySelectorAll("[data-include]").forEach(async (el) => {
   const path = el.getAttribute("data-include"); // gets path from divs data-include attribute
 
@@ -27,6 +41,6 @@ document.querySelectorAll("[data-include]").forEach(async (el) => {
     }
   } catch (err) {
     // in case of error, shows error message inside the div
-    el.innerHTML = `<p style="color:red">Sisällön lataus epäonnistui: ${path}</p>`;
+    el.innerHTML = `<p style="color:red">Sisällön lataus epäonnistui: ${escapeHTML(path)}</p>`;
   }
 });


### PR DESCRIPTION
Potential fix for [https://github.com/lapinamk-gh-opas/lapinamk-gh-opas.github.io/security/code-scanning/2](https://github.com/lapinamk-gh-opas/lapinamk-gh-opas.github.io/security/code-scanning/2)

To fix the vulnerability, the value of `path` (which originates from a DOM attribute and is thus potentially attacker-controlled) should be escaped before being interpolated as HTML and inserted into the DOM. This prevents HTML metacharacters (like `<`, `>`, `&`, `"`, `'`) in `path` from being interpreted as HTML markup, mitigating XSS risk. The most straightforward fix is to introduce an escaping function that converts these characters to their corresponding HTML entities, e.g. replacing `<` with `&lt;`, etc. The escaped value should then be used in the error message (`el.innerHTML = ...`). All edits should be limited to the provided code in `assets/js/includes.js`, adding a suitable escapeHTML function and applying it to `path` in the relevant line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
