### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/includeReusableAccordion.js
+++ b/assets/js/includeReusableAccordion.js
@@ -1,3 +1,12 @@
+// Helper to escape HTML meta-characters in strings
+function escapeHTML(str) {
+  return str.replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 document.addEventListener("accordion:loaded", () => {
   const reusedAccordion = document.querySelectorAll(".reused-accordion");
   console.log("reused-accordion: ", reusedAccordion);
@@ -14,7 +23,7 @@ document.addEventListener("accordion:loaded", () => {
       document.dispatchEvent(new Event("reusedAccordion:loaded"));
     } catch (err) {
       // in case of error, shows error message inside the div
-      accordion.innerHTML = `<p style="color:red">Sisällön lataus epäonnistui: ${path}</p>`;
+      accordion.innerHTML = `<p style="color:red">Sisällön lataus epäonnistui: ${escapeHTML(path)}</p>`;
     }
   });
 });


### PR DESCRIPTION
Potential fix for [https://github.com/lapinamk-gh-opas/lapinamk-gh-opas.github.io/security/code-scanning/1](https://github.com/lapinamk-gh-opas/lapinamk-gh-opas.github.io/security/code-scanning/1)

To safely display the error message with the potentially tainted path, the string must be **HTML-encoded/escaped** before interpolation into an HTML string. This prevents any HTML tags or special characters from being interpreted by the browser.

**Best practice:**  
- Create a small helper function, e.g., `escapeHTML`, that replaces special HTML characters (`<`, `>`, `&`, `"`, `'`) in the string with their corresponding entities.
- Apply `escapeHTML()` to `path` before including it in the interpolated HTML string.
- All changes are made only to the file and region shown, on line 17 (and the new helper function).

**Required changes:**  
- Define an `escapeHTML` function at the top of the file (or above usage).
- Replace the vulnerable interpolation at line 17 with an escaped version.
- No new imports are required, as this is a simple encoding and can be written in one line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
