### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/sidebar.js
+++ b/assets/js/sidebar.js
@@ -3,6 +3,20 @@
 var sidebarState = sessionStorage.getItem("sidebar");
 
 // 0. Load table files that are included in sidebar
+/**
+ * Escape special HTML characters to prevent XSS.
+ * @param {string} unsafe
+ * @returns {string} Escaped HTML
+ */
+function escapeHTML(unsafe) {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 document.addEventListener("sidebar-component:loaded", () => {
   // Process any data-include elements within the sidebar (like table files)
   const sidebarIncludes = document.querySelectorAll("#sidebar [data-include]");
@@ -17,7 +31,7 @@ document.addEventListener("sidebar-component:loaded", () => {
         const html = await content.text();
         el.outerHTML = html;
       } catch (err) {
-        el.innerHTML = `<p style="color:red">Sisällön lataus epäonnistui: ${path}</p>`;
+        el.innerHTML = `<p style="color:red">Sisällön lataus epäonnistui: ${escapeHTML(path)}</p>`;
       }
     })();
     loadPromises.push(loadPromise);


### PR DESCRIPTION
Potential fix for [https://github.com/lapinamk-gh-opas/lapinamk-gh-opas.github.io/security/code-scanning/3](https://github.com/lapinamk-gh-opas/lapinamk-gh-opas.github.io/security/code-scanning/3)

To fix the vulnerability, ensure that the value of `path` is properly escaped before being injected as HTML. Since the intent is to display the value as part of an error message, we should encode any special HTML characters present in `path` (such as `<`, `>`, `&`, `"` etc.) to their corresponding HTML entities, so that injected markup is neutralized and only displayed as text.

**How to fix**:  
- Add a utility function to escape HTML meta-characters.
- Before interpolating `path` in the error message, apply this escaping.
- Change the code at line 20 to output the safe, encoded value of `path`.

**Where to fix**:  
- In assets/js/sidebar.js, inside the catch block where `el.innerHTML` is set.

**What is needed**:  
- Add an `escapeHTML` function to sidebar.js (above the event listener).
- Use it to escape `path` before interpolation in the error message.
- No new external libraries are strictly required; this can be done in vanilla JS.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
